### PR TITLE
Backport changes done in BalenaWPE for "Weston output configuration options"

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,10 @@ background-image=/data/wallpapers/MyWallpaper.jpg
 
 ### Environment variables
 
-| Environment variable   | Default               | Example
-|------------------------|-----------------------|---------------------
-| **`WESTON_IDLE_TIME`** | 0 (never)             | 900
+| Environment variable                 | Default               | Example
+|--------------------------------------|-----------------------|---------------------
+| **`WESTON_IDLE_TIME`**               | 0 (never)             | 900
+| **`WESTON_OUTPUT_USE_CURRENT_MODE`** | 0                     | 1
 
 
 ## How to build

--- a/README.md
+++ b/README.md
@@ -83,8 +83,22 @@ background-image=/data/wallpapers/MyWallpaper.jpg
 | Environment variable                 | Default               | Example
 |--------------------------------------|-----------------------|---------------------
 | **`WESTON_IDLE_TIME`**               | 0 (never)             | 900
-| **`WESTON_OUTPUT_USE_CURRENT_MODE`** | 0                     | 1
 
+#### Compositor settings
+
+The browser relies on the Weston compositor to work. While the defaults are
+fine for most uses, some tweaks are allowed regarding the output resolution.
+
+| Environment variable                       | Options   | Default | Description
+|--------------------------------------------|-----------|---------|---------------------------------------------------
+| **`WESTON_OUTPUT_USE_CURRENT_MODE`**       | `0`, `1`  | `0`     | Inherit the display mode from KMS console
+| **`WESTON_OUTPUT_MAX_WIDTH`**              | `integer` | `0`     | Maximum horizontal resolution the compositor may set
+| **`WESTON_OUTPUT_MAX_HEIGHT`**             | `integer` | `0`     | Maximum vertical resolution the compositor may set
+
+The maximum-resolution environment variables rely on the list of modes
+advertised by the DRM subsystem. That means if you set for example the
+maximum horizontal resolution to `1920` and the list contains `3840x2160`,
+`2560x1440`, `1920x1080` and `1280x800`, `1920x1080` will be picked.
 
 ## How to build
 

--- a/balena.yml
+++ b/balena.yml
@@ -27,6 +27,10 @@ assets:
       url: 'https://raw.githubusercontent.com/Igalia/balena-weston/main/logo.svg'
 data:
   defaultDeviceType: raspberrypi4-64
+  applicationEnvironmentVariables:
+    - WESTON_OUTPUT_USE_CURRENT_MODE: 0
+    - WESTON_OUTPUT_MAX_WIDTH: 0
+    - WESTON_OUTPUT_MAX_HEIGHT: 0
   supportedDeviceTypes:
     - raspberrypi4-64
     - raspberrypi3

--- a/balena/weston-init
+++ b/balena/weston-init
@@ -27,6 +27,60 @@ startup-animation=fade
 
 IEOF
 
+WESTON_OUTPUT_MAX_WIDTH=${WESTON_OUTPUT_MAX_WIDTH:-0}
+WESTON_OUTPUT_MAX_HEIGHT=${WESTON_OUTPUT_MAX_HEIGHT:-0}
+
+is_in_range() {
+    test "$2" -eq 0 -o "$1" -le "$2"
+}
+
+# Limit resolution if necessary
+if [ "$WESTON_OUTPUT_MAX_WIDTH" -gt 0 -o "$WESTON_OUTPUT_MAX_HEIGHT" -gt 0 ]; then
+    for outp in /sys/class/drm/card*-*; do
+        # no outputs
+        if [ ! -d "$outp" ]; then
+            break
+        fi
+        # skip if not enabled
+        if [ "$(cat ${outp}/enabled)" = "disabled" ]; then
+            continue
+        fi
+        # get the output name
+        outn=${outp#*-}
+        # check the modes
+        moden=0
+        foundres=
+        for mode in $(cat "${outp}/modes"); do
+            wres=${mode%x*}
+            hres=${mode#*x}
+            moden=$(($moden + 1))
+            # skip interlaced modes and other junk
+            if ! [ "$wres" -eq "$wres" -a "$hres" -eq "$hres" ] 2> /dev/null; then
+                continue
+            fi
+            # check resolution constraints
+            if ! is_in_range "$wres" "$WESTON_OUTPUT_MAX_WIDTH"; then
+                continue
+            fi
+            if ! is_in_range "$hres" "$WESTON_OUTPUT_MAX_HEIGHT"; then
+                continue
+            fi
+            # found an acceptable res
+            foundres="$mode"
+            break
+        done
+        # found a res to use and it's non-preferred, override in weston
+        if [ -n "$foundres" -a "$moden" -gt 1 ]; then
+            cat << IEOF >> /weston.ini
+
+[output]
+name=${outn}
+mode=${foundres}
+IEOF
+        fi
+    done
+fi
+
 WESTON_OUTPUT_USE_CURRENT_MODE=${WESTON_OUTPUT_USE_CURRENT_MODE:-0}
 
 # Allow usage of --current-mode, to let the host system decide the resolution

--- a/balena/weston-init
+++ b/balena/weston-init
@@ -27,4 +27,13 @@ startup-animation=fade
 
 IEOF
 
-weston --idle-time ${WESTON_IDLE_TIME} --tty 2 -c /weston.ini
+WESTON_OUTPUT_USE_CURRENT_MODE=${WESTON_OUTPUT_USE_CURRENT_MODE:-0}
+
+# Allow usage of --current-mode, to let the host system decide the resolution
+if [ "$WESTON_OUTPUT_USE_CURRENT_MODE" -eq 1 ]; then
+       WESTON_CURRENT_MODE="--current-mode"
+else
+       WESTON_CURRENT_MODE=""
+fi
+
+weston ${WESTON_CURRENT_MODE} --idle-time ${WESTON_IDLE_TIME} --tty 2 -c /weston.ini


### PR DESCRIPTION
The first commit allows device users to configure their display mode via hdmi_mode and have weston respect it. Otherwise, weston will always try to use the highest available mode by default, which e.g. for 4K screens is too slow to be practical.

The second commit adds a degree of configurability, to be used when you don't want the --current-mode (i.e. when it's too inflexible for you). This is primarily useful when you have a variety of raspberry pi devices in your fleet that are connected to displays of varying resolutions that may include 4K displays as well as 720p displays, and you want to use native resolution for all but the 4K displays, but for 4K displays you want to use 1080p, because of 4K on raspberry pi being too slow.

**Notice:** This PR get rid off the WPE_ prefix in the envvars

Related to https://github.com/Igalia/balena-wpe/pull/19/files