### PR TITLE
Implement a Weston shell override

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,25 +80,24 @@ background-image=/data/wallpapers/MyWallpaper.jpg
 
 ### Environment variables
 
-| Environment variable                 | Default               | Example
-|--------------------------------------|-----------------------|---------------------
-| **`WESTON_IDLE_TIME`**               | 0 (never)             | 900
+There are several environment variables that can be used to tweak
+the Weston settings. The defaults should be okay for most cases.
 
-#### Compositor settings
-
-The browser relies on the Weston compositor to work. While the defaults are
-fine for most uses, some tweaks are allowed regarding the output resolution.
-
-| Environment variable                       | Options   | Default | Description
-|--------------------------------------------|-----------|---------|---------------------------------------------------
-| **`WESTON_OUTPUT_USE_CURRENT_MODE`**       | `0`, `1`  | `0`     | Inherit the display mode from KMS console
-| **`WESTON_OUTPUT_MAX_WIDTH`**              | `integer` | `0`     | Maximum horizontal resolution the compositor may set
-| **`WESTON_OUTPUT_MAX_HEIGHT`**             | `integer` | `0`     | Maximum vertical resolution the compositor may set
+| Environment variable                       | Options   | Default   | Description
+|--------------------------------------------|-----------|-----------|---------------------
+| **`WESTON_IDLE_TIME`**                     | `integer` | 0 (never) | Idle time in seconds (e.g. 900)
+| **`WESTON_SHELL`**                         | `string`  | `desktop` | The shell to use (`desktop`, `fullscreen`, `kiosk` etc.)
+| **`WESTON_OUTPUT_USE_CURRENT_MODE`**       | `0`, `1`  | `0`       | Inherit the display mode from KMS console
+| **`WESTON_OUTPUT_MAX_WIDTH`**              | `integer` | `0`       | Maximum horizontal resolution the compositor may set
+| **`WESTON_OUTPUT_MAX_HEIGHT`**             | `integer` | `0`       | Maximum vertical resolution the compositor may set
 
 The maximum-resolution environment variables rely on the list of modes
 advertised by the DRM subsystem. That means if you set for example the
 maximum horizontal resolution to `1920` and the list contains `3840x2160`,
 `2560x1440`, `1920x1080` and `1280x800`, `1920x1080` will be picked.
+
+The shell used will be `${WESTON_SHELL}-shell.so`. You can use any shell
+shipped with Weston by default.
 
 ## How to build
 

--- a/balena.yml
+++ b/balena.yml
@@ -28,6 +28,8 @@ assets:
 data:
   defaultDeviceType: raspberrypi4-64
   applicationEnvironmentVariables:
+    - WESTON_IDLE_TIME: 0
+    - WESTON_SHELL: desktop
     - WESTON_OUTPUT_USE_CURRENT_MODE: 0
     - WESTON_OUTPUT_MAX_WIDTH: 0
     - WESTON_OUTPUT_MAX_HEIGHT: 0

--- a/balena/weston-init
+++ b/balena/weston-init
@@ -90,4 +90,6 @@ else
        WESTON_CURRENT_MODE=""
 fi
 
-weston ${WESTON_CURRENT_MODE} --idle-time ${WESTON_IDLE_TIME} --tty 2 -c /weston.ini
+WESTON_SHELL=${WESTON_SHELL:-desktop}
+
+weston ${WESTON_CURRENT_MODE} --shell ${WESTON_SHELL}-shell.so --idle-time ${WESTON_IDLE_TIME} --tty 2 -c /weston.ini


### PR DESCRIPTION
While at it, also clean up the README to make more sense and add WESTON_IDLE_TIME to balena.yml.

A lot of cases like digital signage will want to use fullscreen-shell or kiosk-shell so that mouse pointer is hidden and so on.